### PR TITLE
Добавить DeviceLocationRepository #4

### DIFF
--- a/yad_core/build.gradle
+++ b/yad_core/build.gradle
@@ -30,8 +30,11 @@ android {
 
 dependencies {
 
+    implementation "androidx.activity:activity:1.2.1"
+    implementation "androidx.activity:activity-ktx:1.2.1"
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.3.0'
+    implementation 'com.google.android.gms:play-services-location:18.0.0'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'

--- a/yad_core/src/main/AndroidManifest.xml
+++ b/yad_core/src/main/AndroidManifest.xml
@@ -2,4 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ru.m2d.yad_core">
 
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
 </manifest>

--- a/yad_core/src/main/java/ru/m2d/yad_core/services/device/repos/DeviceLocationRepo.java
+++ b/yad_core/src/main/java/ru/m2d/yad_core/services/device/repos/DeviceLocationRepo.java
@@ -1,0 +1,154 @@
+package ru.m2d.yad_core.services.device.repos;
+
+import android.Manifest;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.os.Looper;
+
+import androidx.core.app.ActivityCompat;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.google.android.gms.location.FusedLocationProviderClient;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
+import com.google.android.gms.location.LocationServices;
+import com.google.android.gms.location.LocationSettingsRequest;
+import com.google.android.gms.location.LocationSettingsResponse;
+import com.google.android.gms.location.SettingsClient;
+import com.google.android.gms.tasks.CancellationTokenSource;
+import com.google.android.gms.tasks.OnSuccessListener;
+
+import org.jetbrains.annotations.NotNull;
+
+import ru.m2d.yad_core.core.models.Location;
+import ru.m2d.yad_core.core.repos.LocationRepo;
+
+
+interface Expression {
+    void performTask();
+}
+
+public class DeviceLocationRepo implements LocationRepo {
+    private final MutableLiveData<Location> data = new MutableLiveData<>();
+
+    // запушен ли startLoopUpdateLocation
+    private boolean isLocationUpdating = false;
+
+
+    private final FusedLocationProviderClient fusedLocationClient;
+
+    // указатель на activity, для которой будет получаться геолокация
+    private final Activity activity;
+    // время обновления геолокации в ms
+    private int timeUpdateLocation;
+
+    // колбэк, вызывающийся в случае обновления локации (метод updatingLocation)
+    // обновляет liveData
+    private final LocationCallback locationUpdatingCallback = new LocationCallback() {
+        @Override
+        public void onLocationResult(@NotNull LocationResult locationResult) {
+            android.location.Location location = locationResult.getLastLocation();
+            // Logic to handle location object
+            Location loc = new Location();
+            loc.latitude = location.getLatitude();
+            loc.longitude = location.getLongitude();
+            data.postValue(loc);
+        }
+    };
+
+    public DeviceLocationRepo(Activity activity) {
+        this.fusedLocationClient = LocationServices.getFusedLocationProviderClient(activity);
+        this.activity = activity;
+    }
+
+    // возвращает самую актуальную геолокацию
+    @Override
+    public LiveData<Location> getLocation() {
+        // передаем requestLocation в качестве параметра в checkLocationRequesting
+        Expression expr = this::requestLocation;
+        // проверка, есть ли права доступа у activity и включена ли геолокация
+        // если нет, то не обновляем data
+        checkLocationRequesting(expr);
+        return data;
+    }
+
+    // начать обновлять геолокацию устройства
+    public void startUpdateLocation(int timeUpdateLocation) {
+        // если время обновления > 0 и цикл обновления геолокации еще не запущен
+        if (timeUpdateLocation > 0 && !this.isLocationUpdating) {
+            this.timeUpdateLocation = timeUpdateLocation;
+            Expression expr = this::updatingLocation;
+            checkLocationRequesting(expr);
+        }
+    }
+
+    // прекратить обновлять значение геолокации
+    // возвращает true, если геолокация перестала обновляться
+    public void stopUpdateLocation() {
+        fusedLocationClient.removeLocationUpdates(this.locationUpdatingCallback);
+        this.isLocationUpdating = false;
+    }
+
+    // обновление геолокации
+    // (проверка прав не нужна, поскольку метод вызывается из
+    // checkLocationRequesting, который осуществляет проверку)
+    @SuppressLint("MissingPermission")
+    private void updatingLocation() {
+        this.isLocationUpdating = true;
+        LocationRequest locationRequest = LocationRequest.create();
+        // задаем время обновления геолокации
+        locationRequest.setInterval(this.timeUpdateLocation);
+        // выставляем точность рассчета геолокации
+        locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+        this.fusedLocationClient.requestLocationUpdates(locationRequest,
+                this.locationUpdatingCallback,
+                Looper.getMainLooper());
+    }
+
+    // делает запрос на получение геолокации устройства и сохраняет ее в data в случае успеха
+    @SuppressLint("MissingPermission")
+    private void requestLocation() {
+        // создаем токен, по которому в теории можно прекратить вызов getCurrentLocation
+        // методом .cancel()
+        // (здесь не используется)
+        CancellationTokenSource cts = new CancellationTokenSource();
+        this.fusedLocationClient.getCurrentLocation(LocationRequest.PRIORITY_HIGH_ACCURACY, cts.getToken())
+                .addOnSuccessListener(this.activity, new OnSuccessListener<android.location.Location>() {
+                    // в случае удачного получения обновляем liveData, иначе ничего не делаем
+                    @Override
+                    public void onSuccess(android.location.Location location) {
+                        if (location != null) {
+                            Location loc = new Location();
+                            loc.latitude = location.getLatitude();
+                            loc.longitude = location.getLongitude();
+                            data.postValue(loc);
+                        }
+                    }
+                });
+    }
+
+    // проверяет, возможно ли получить геолокацию устройства
+    // (разрешены ли права и включена ли геолокация на устройстве)
+    private void checkLocationRequesting(Expression onSuccessFunc) {
+        // проверка, есть ли права доступа у activity
+        if (ActivityCompat.checkSelfPermission(
+                this.activity, Manifest.permission.ACCESS_FINE_LOCATION) ==
+                PackageManager.PERMISSION_GRANTED) {
+            // проверка, включена ли геолокация
+            LocationSettingsRequest.Builder builder = new LocationSettingsRequest.Builder();
+            SettingsClient client = LocationServices.getSettingsClient(this.activity);
+            client.checkLocationSettings(builder.build())
+                    .addOnSuccessListener(this.activity, new OnSuccessListener<LocationSettingsResponse>() {
+                        @Override
+                        public void onSuccess(LocationSettingsResponse locationSettingsResponse) {
+                            onSuccessFunc.performTask();
+                        }
+                    });
+        }
+    }
+
+
+}

--- a/yad_core/src/main/java/ru/m2d/yad_core/services/device/repos/DeviceLocationRepo.java
+++ b/yad_core/src/main/java/ru/m2d/yad_core/services/device/repos/DeviceLocationRepo.java
@@ -92,7 +92,6 @@ public class DeviceLocationRepo implements LocationRepo {
     }
 
     // прекратить обновлять значение геолокации
-    // возвращает true, если геолокация перестала обновляться
     public void stopUpdateLocation() {
         if (this.isLocationUpdating) {
             fusedLocationClient.removeLocationUpdates(this.locationUpdatingCallback);


### PR DESCRIPTION
resolve #4.
Добавлен класс DeviceLocationRepository, позволяющий получать геолокацию устройства в виде широты и долготы.
Используется [Build location-aware apps](https://developer.android.com/training/location/).
При создании класса необходимо передать ему в качестве параметра Activity, вызывающей его.

У класса 3 публичных метода:
- getLocation() - получает геолокацию и возвращает liveData<Location>.
- startUpdateLocation(timeUpdateLocation) - начинает обновлять liveData<Location> каждые timeUpdateLocation секунд.
- stopUpdateLocation() - прекращает обновление геолокации.

В классе присутствует проверка прав доступа пользователя, а также проверка, включена ли геолокация. В случае не выполнения проверки, методы ничего не делают (программа не завершается аварийно).

В классе нет вызова запроса пользователя на разрешение прав доступа приложению, а также просьбы включить геолокацию в настройках, поскольку эта часть относится к ui.